### PR TITLE
Added .env.backup to Laravel.gitignore

### DIFF
--- a/Laravel.gitignore
+++ b/Laravel.gitignore
@@ -17,6 +17,7 @@ public_html/hot
 
 storage/*.key
 .env
+.env.backup
 Homestead.yaml
 Homestead.json
 /.vagrant


### PR DESCRIPTION
**Reasons for making this change:**

Last version of the Laravel uses .env.backup

**Links to documentation supporting these rule changes:**

(https://github.com/laravel/laravel/blob/9.x/.gitignore)

